### PR TITLE
fix(jira-client): migrate search to v3 search/jql + bump v1.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "agent-team-creator",
       "description": "Analyze codebase architecture and tech stack to automatically generate specialized Claude Code agent teams",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "author": {
         "name": "Christian Picon Calderon",
         "email": "c.picon@uniandes.edu.co"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-05-07
+
+### Fixed
+- `jira_client.py`: `search-issues` action migrated from the removed `/rest/api/2/search` endpoint to `POST /rest/api/3/search/jql`. Atlassian returned `HTTP 410: The requested API has been removed` on the old route, which broke duplicate detection during `/generate-jira-task` in REST mode. See [Atlassian CHANGE-2046](https://developer.atlassian.com/changelog/#CHANGE-2046).
+
+### Changed
+- `jira_client.py`: `search-issues` response now reports `total` from a separate non-fatal call to `POST /rest/api/3/search/approximate-count` (the new endpoint no longer returns `total`). If the secondary call fails, `total` falls back to `len(issues)` so the search still returns useful data. The response also exposes `nextPageToken` when more results are available, since the new endpoint uses token-based pagination instead of `startAt`.
+- `jira-rest-api` skill: documentation updated to reflect the new endpoint, approximate `total` semantics, and `nextPageToken` pagination model. Skill version bumped to `1.1.0`.
+
+### Internal
+- `jira_client.py`: extracted `_build_authed_request` helper shared by `make_request` and the new non-fatal `try_request` (used for the optional approximate-count call). No behavior change to existing actions.
+
 ## [1.1.1] - 2026-04-20
 
 ### Fixed
@@ -74,7 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-phase command execution with agent orchestration
 - Graceful fallback modes when external services unavailable
 
-[Unreleased]: https://github.com/Cpicon/claude-code-plugins/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/Cpicon/claude-code-plugins/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/Cpicon/claude-code-plugins/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/Cpicon/claude-code-plugins/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/Cpicon/claude-code-plugins/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/Cpicon/claude-code-plugins/releases/tag/v1.0.0

--- a/agent-team-creator/.claude-plugin/plugin.json
+++ b/agent-team-creator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-team-creator",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Analyze codebase architecture and tech stack to automatically generate specialized Claude Code agent teams",
   "author": {
     "name": "Christian Picon Calderon",

--- a/agent-team-creator/scripts/jira_client.py
+++ b/agent-team-creator/scripts/jira_client.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Jira REST API v2 client for Claude Code plugin fallback.
+"""Jira REST API client for Claude Code plugin fallback.
 
 Zero external dependencies — uses only Python 3 stdlib.
 Credentials read from config file (never CLI args).
@@ -40,25 +40,27 @@ def read_config(path):
 
 # --- HTTP ---
 
-def make_request(config, method, path, body=None, timeout=15):
-    """Execute an authenticated HTTP request to Jira REST API v2.
-
-    Returns parsed JSON response.
-    Raises urllib.error.HTTPError or urllib.error.URLError on failure.
-    """
+def _build_authed_request(config, method, path, body):
+    """Build an authenticated urllib.Request (no I/O)."""
     url = f"{config['baseUrl']}{path}"
     credentials = f"{config['email']}:{config['apiToken']}"
     auth_header = base64.b64encode(credentials.encode()).decode()
-
     headers = {
         "Authorization": f"Basic {auth_header}",
         "Content-Type": "application/json",
         "Accept": "application/json",
     }
-
     data = json.dumps(body).encode() if body else None
-    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    return urllib.request.Request(url, data=data, headers=headers, method=method)
 
+
+def make_request(config, method, path, body=None, timeout=15):
+    """Execute an authenticated HTTP request to Jira REST API.
+
+    Returns parsed JSON response.
+    Calls error_exit() on HTTP errors (auth, network, server, jira-api).
+    """
+    req = _build_authed_request(config, method, path, body)
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             if resp.status == 204:
@@ -70,6 +72,22 @@ def make_request(config, method, path, body=None, timeout=15):
         if "timed out" in str(e.reason):
             error_exit("Request timed out", 3)
         error_exit(f"Cannot reach {config['baseUrl']}: {e.reason}", 3)
+
+
+def try_request(config, method, path, body=None, timeout=10):
+    """Non-fatal variant of make_request: returns None on any failure.
+
+    Use for optional/secondary calls where the action should still succeed
+    if this call fails (e.g., approximate-count for duplicate detection).
+    """
+    req = _build_authed_request(config, method, path, body)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            if resp.status == 204:
+                return {}
+            return json.loads(resp.read().decode())
+    except Exception:
+        return None
 
 
 def make_request_with_retry(config, method, path, body=None, retries=1):
@@ -238,14 +256,27 @@ def action_get_projects(config, args):
 
 
 def action_search_issues(config, args):
-    """Search issues via JQL."""
+    """Search issues via JQL using /rest/api/3/search/jql.
+
+    Atlassian removed /rest/api/2/search and /rest/api/3/search (HTTP 410)
+    in favor of a token-paginated endpoint that no longer returns `total`.
+    To preserve duplicate-detection UX ("Found ~47 similar issues"), we
+    fetch an approximate count from /rest/api/3/search/approximate-count
+    in a separate non-fatal call. Failures there degrade to the page size.
+
+    See: https://developer.atlassian.com/changelog/#CHANGE-2046
+    """
     payload = read_payload(args.payload_file)
+    jql = payload.get("jql", "")
     body = {
-        "jql": payload.get("jql", ""),
+        "jql": jql,
         "maxResults": payload.get("maxResults", 5),
         "fields": payload.get("fields", ["summary", "status", "created", "key"]),
     }
-    data = make_request(config, "POST", "/rest/api/2/search", body)
+    if payload.get("nextPageToken"):
+        body["nextPageToken"] = payload["nextPageToken"]
+
+    data = make_request(config, "POST", "/rest/api/3/search/jql", body)
     issues = []
     for issue in data.get("issues", []):
         fields = issue.get("fields", {})
@@ -256,7 +287,16 @@ def action_search_issues(config, args):
             "status": status.get("name", "") if isinstance(status, dict) else str(status),
             "created": fields.get("created", ""),
         })
-    return {"ok": True, "issues": issues, "total": data.get("total", 0)}
+
+    count_data = try_request(
+        config, "POST", "/rest/api/3/search/approximate-count", {"jql": jql}
+    )
+    total = count_data.get("count", len(issues)) if count_data else len(issues)
+
+    result = {"ok": True, "issues": issues, "total": total}
+    if data.get("nextPageToken"):
+        result["nextPageToken"] = data["nextPageToken"]
+    return result
 
 
 def action_get_issue_types(config, args):
@@ -395,7 +435,7 @@ ACTIONS = {
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Jira REST API v2 client")
+    parser = argparse.ArgumentParser(description="Jira REST API client")
     parser.add_argument("--action", required=True, choices=ACTIONS.keys())
     parser.add_argument("--config", required=True, help="Path to credential config JSON")
     parser.add_argument("--issue-key", dest="issue_key", help="Jira issue key (e.g., PROJ-123)")

--- a/agent-team-creator/skills/jira-rest-api/SKILL.md
+++ b/agent-team-creator/skills/jira-rest-api/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: Jira REST API
-description: Knowledge for invoking the Jira REST API v2 via jira_client.py.
+description: Knowledge for invoking the Jira REST API via jira_client.py.
   Used by commands (generate-jira-task, update-generated-report) as a fallback
   when the Atlassian MCP plugin is unavailable. Contains credential configuration,
   script invocation syntax, action reference, error handling, and security guidance.
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Jira REST API Client
 
 This skill documents the REST API fallback tier for the Jira integration. When the
 Atlassian MCP plugin is unavailable, commands use the `jira_client.py` script to
-interact with Jira directly via REST API v2.
+interact with Jira directly via REST API v2 — except for issue search, which uses
+the v3 `/search/jql` endpoint after Atlassian removed the v2/v3 `/search` routes
+(HTTP 410, see [CHANGE-2046](https://developer.atlassian.com/changelog/#CHANGE-2046)).
 
 ## Architecture
 
@@ -55,12 +57,23 @@ Credentials are ALWAYS read from the config file. Never pass tokens as CLI argum
 |--------|---------------|----------------|---------|
 | `verify-auth` | `--config` | — | `{ok, email, displayName}` |
 | `get-projects` | `--config` | `--query` | `{ok, projects: [{key,name,id}]}` |
-| `search-issues` | `--config --payload-file` | — | `{ok, issues: [{key,summary,status}], total}` |
+| `search-issues` | `--config --payload-file` | — | `{ok, issues: [{key,summary,status,created}], total, nextPageToken?}` |
 | `get-issue-types` | `--config --project` | — | `{ok, issueTypes: [{name,id}]}` |
 | `create-issue` | `--config --payload-file` | — | `{ok, key, url}` |
 | `get-issue` | `--config --issue-key` | — | `{ok, key, summary, description, status, comments}` |
 | `add-comment` | `--config --issue-key --payload-file` | — | `{ok, commentId}` |
 | `get-accessible-resources` | `--config` | — | `{ok, baseUrl}` (alias for verify-auth) |
+
+### Notes on `search-issues`
+
+- Endpoint: `POST /rest/api/3/search/jql` (the v2/v3 `/search` routes were removed by Atlassian).
+- `total` is an **approximate** count fetched from `/rest/api/3/search/approximate-count`
+  in a separate non-fatal call. If that secondary call fails, `total` falls back to
+  `len(issues)` so the search still returns useful data.
+- Pagination is **token-based**, not offset-based. When more results exist beyond
+  `maxResults`, the response includes `nextPageToken`; pass it back in the next
+  payload's `nextPageToken` field to fetch the next page. There is no `startAt`.
+- Default `maxResults` is `5`; payload may override (Jira caps at 100).
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary

- Re-enables Jira duplicate-detection search after Atlassian removed `/rest/api/2/search` (HTTP 410, [CHANGE-2046](https://developer.atlassian.com/changelog/#CHANGE-2046)). The script now POSTs to `/rest/api/3/search/jql`.
- Restores the `total` field via a separate non-fatal call to `/rest/api/3/search/approximate-count` (the new endpoint no longer returns `total`). Falls back to `len(issues)` if the count call fails.
- Bumps plugin version `1.1.1` → `1.1.2` and updates CHANGELOG.

## Why now

The user's `/generate-jira-task` flow in REST mode crashed mid-search with `HTTP 410: API has been removed`, blocking duplicate detection and Jira ticket creation. Verified the fix end-to-end against a real Jira project (PDE) — all three paths (matches, no matches, regression check on `verify-auth`) return clean JSON with exit 0.

## What changed

| File | Change |
|------|--------|
| `agent-team-creator/scripts/jira_client.py` | `action_search_issues` now hits `/rest/api/3/search/jql`; adds `try_request` non-fatal helper and shared `_build_authed_request` builder; secondary `/search/approximate-count` call populates `total`. |
| `agent-team-creator/skills/jira-rest-api/SKILL.md` | Documents new endpoint, approximate `total` semantics, and `nextPageToken` pagination. Skill version bumped to `1.1.0`. |
| `CHANGELOG.md` | New `[1.1.2] - 2026-05-07` entry under Fixed/Changed/Internal. |
| `agent-team-creator/.claude-plugin/plugin.json` | Version `1.1.1` → `1.1.2`. |
| `.claude-plugin/marketplace.json` | Version `1.1.1` → `1.1.2`. |

## Test plan

- [x] Syntax check (`python3 -c "import ast; ast.parse(...)"`)
- [x] Real Jira call against PDE project: returned issues + `total: 89` + `nextPageToken`
- [x] Reproduced the failing duplicate-check JQL: returned PDE-116, `total: 1`
- [x] Zero-match query: returned `[]`, `total: 0`
- [x] `verify-auth` regression check after `make_request` refactor: still works
- [ ] Reviewer to spot-check once more before merge

## Post-merge steps

After merge, tag the merged main commit and push:

```bash
git checkout main && git pull
git tag -a v1.1.2 -m "Release v1.1.2"
git push origin v1.1.2
```

The local `v1.1.2` tag was deliberately not pushed with the branch so it can be created on the merged SHA (works regardless of merge strategy chosen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)