### PR TITLE
feat(jira): expand jira_client.py + wire generate-jira-task (v1.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "agent-team-creator",
       "description": "Analyze codebase architecture and tech stack to automatically generate specialized Claude Code agent teams",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "author": {
         "name": "Christian Picon Calderon",
         "email": "c.picon@uniandes.edu.co"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "agent-team-creator",
       "description": "Analyze codebase architecture and tech stack to automatically generate specialized Claude Code agent teams",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "author": {
         "name": "Christian Picon Calderon",
         "email": "c.picon@uniandes.edu.co"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-08
+
+### Added
+- `jira_client.py`: `update-issue` action — patch summary, description, labels, priority, assignee, or any raw field on an existing issue via `PUT /rest/api/2/issue/{key}`. Includes a `fields` escape hatch for custom fields the script doesn't model directly.
+- `jira_client.py`: `attach-file` action — upload any local file (markdown, logs, screenshots) as a Jira attachment via multipart `POST /rest/api/2/issue/{key}/attachments`. Sends `X-Atlassian-Token: no-check` as required by Atlassian.
+- `jira_client.py`: `delete-issue` action — `DELETE /rest/api/2/issue/{key}`. Cascades to subtasks by default; `--no-cascade` flag refuses deletion when subtasks exist.
+- `jira_client.py`: `get-current-user` action — clearer-named alias for `verify-auth`. Returns `{accountId, email, displayName}` for the authenticated user. Useful for self-assignment without the user having to know their accountId.
+- `jira_client.py`: new CLI flags `--file-path` (for `attach-file`) and `--no-cascade` (for `delete-issue`).
+- `jira-rest-api` skill: documented the 5 new actions with payload patterns and invocation examples. Skill version bumped to `1.2.0`.
+- `/generate-jira-task` Phase 5 step 7: derives priority from impact assessment, resolves the current user's accountId, and prompts the user (single batched `AskUserQuestion`) for priority and assignee selection. Defaults are Recommended in both questions.
+- `/generate-jira-task` Phase 6 (REST mode): now attaches the source debugging report `.md` to the new Jira issue after creation, so the original artifact lives on the ticket alongside the formatted summary. Non-fatal — attachment failure does not abort issue creation.
+
+### Changed
+- `jira_client.py`: `create-issue` payload accepts three new optional fields: `priority` (string name, e.g. "High"), `assignee_account_id` (Atlassian accountId), and `parent_key` (parent issue key for subtasks). Existing callers that don't pass these fields see identical behavior.
+- `/generate-jira-task` Phase 6 (REST and MCP create paths): tickets are now created with priority + assignee in a single API call instead of being created with defaults and immediately patched.
+- `/generate-jira-task` Phase 6 (OFFLINE draft): markdown draft now includes priority and an explicit instruction to attach the source debug report when manually creating the ticket.
+- `/generate-jira-task` Phase 6 (MCP create): `additional_fields` now includes `priority.name` and (when not unassigned) `assignee.accountId`. Note: file attachment is not supported by the Atlassian MCP tools today; only REST mode attaches the source report.
+
+### Internal
+- `jira_client.py`: `create-issue` body construction refactored to build the `fields` dict incrementally before submission, accommodating the new optional fields without nesting conditionals inside the request body literal.
+
 ## [1.1.2] - 2026-05-07
 
 ### Fixed
@@ -86,7 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-phase command execution with agent orchestration
 - Graceful fallback modes when external services unavailable
 
-[Unreleased]: https://github.com/Cpicon/claude-code-plugins/compare/v1.1.2...HEAD
+[Unreleased]: https://github.com/Cpicon/claude-code-plugins/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/Cpicon/claude-code-plugins/compare/v1.1.2...v1.2.0
 [1.1.2]: https://github.com/Cpicon/claude-code-plugins/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/Cpicon/claude-code-plugins/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/Cpicon/claude-code-plugins/compare/v1.0.0...v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-05-07
+
+### Fixed
+- `jira_client.py`: `search-issues` action migrated from the removed `/rest/api/2/search` endpoint to `POST /rest/api/3/search/jql`. Atlassian returned `HTTP 410: The requested API has been removed` on the old route, which broke duplicate detection during `/generate-jira-task` in REST mode. See [Atlassian CHANGE-2046](https://developer.atlassian.com/changelog/#CHANGE-2046).
+
+### Changed
+- `jira_client.py`: `search-issues` response now reports `total` from a separate non-fatal call to `POST /rest/api/3/search/approximate-count` (the new endpoint no longer returns `total`). If the secondary call fails, `total` falls back to `len(issues)` so the search still returns useful data. The response also exposes `nextPageToken` when more results are available, since the new endpoint uses token-based pagination instead of `startAt`.
+- `jira-rest-api` skill: documentation updated to reflect the new endpoint, approximate `total` semantics, and `nextPageToken` pagination model. Skill version bumped to `1.1.0`.
+
+### Internal
+- `jira_client.py`: extracted `_build_authed_request` helper shared by `make_request` and the new non-fatal `try_request` (used for the optional approximate-count call). No behavior change to existing actions.
+
 ## [1.1.1] - 2026-04-20
 
 ### Fixed
@@ -74,7 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-phase command execution with agent orchestration
 - Graceful fallback modes when external services unavailable
 
-[Unreleased]: https://github.com/Cpicon/claude-code-plugins/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/Cpicon/claude-code-plugins/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/Cpicon/claude-code-plugins/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/Cpicon/claude-code-plugins/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/Cpicon/claude-code-plugins/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/Cpicon/claude-code-plugins/releases/tag/v1.0.0

--- a/agent-team-creator/.claude-plugin/plugin.json
+++ b/agent-team-creator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-team-creator",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Analyze codebase architecture and tech stack to automatically generate specialized Claude Code agent teams",
   "author": {
     "name": "Christian Picon Calderon",

--- a/agent-team-creator/.claude-plugin/plugin.json
+++ b/agent-team-creator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-team-creator",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Analyze codebase architecture and tech stack to automatically generate specialized Claude Code agent teams",
   "author": {
     "name": "Christian Picon Calderon",

--- a/agent-team-creator/commands/generate-jira-task.md
+++ b/agent-team-creator/commands/generate-jira-task.md
@@ -419,6 +419,41 @@ Execute phases 0-6 in order. Track `JIRA_MODE` state throughout.
    | `**Labels:**` | Parse as comma-separated list or bracketed array | labels array |
    | `**Acceptance Criteria:**` | Include in description | (part of description) |
 
+7. **Determine priority and assignee** (COMMAND responsibility)
+
+   **Auto-derive priority** from the Impact Assessment section of the debugging report:
+
+   | Impact wording | Mapped priority |
+   |----------------|-----------------|
+   | "critical", "highest", "P0" | `Highest` |
+   | "high", "P1" | `High` |
+   | "medium", "P2", or unclear | `Medium` (default) |
+   | "low", "P3", "minor" | `Low` |
+   | "lowest", "trivial" | `Lowest` |
+
+   Store as `derivedPriority`.
+
+   **Resolve current user accountId**:
+   - `JIRA_MODE = "MCP"`: Call `mcp__plugin_atlassian_atlassian__atlassianUserInfo()` and extract `accountId` + `displayName`.
+   - `JIRA_MODE = "REST"`: Bash `python3 {SCRIPT_PATH} --action get-current-user --config .claude/jira-rest-config.json`. Parse stdout for `accountId` + `displayName`.
+   - `JIRA_MODE = "OFFLINE"`: Skip — assignment will be left blank in the markdown draft.
+
+   Store as `currentUser = {accountId, displayName}`.
+
+   **Confirm with user** via a single `AskUserQuestion` call with two questions:
+
+   - **Q1 — Priority**: "Set ticket priority?"
+     - Options:
+       - `Use auto-derived ({derivedPriority})` (Recommended) → `selectedPriority = derivedPriority`
+       - `Highest` / `High` / `Medium` / `Low` (3 most common alternatives, omit Lowest unless `derivedPriority == Lowest`)
+     - Store the result as `selectedPriority`.
+
+   - **Q2 — Assignee** (skip in OFFLINE mode):
+     - Options:
+       - `Assign to me ({currentUser.displayName})` (Recommended) → `selectedAssigneeAccountId = currentUser.accountId`
+       - `Leave unassigned` → `selectedAssigneeAccountId = null`
+     - Store the result as `selectedAssigneeAccountId`.
+
 ---
 
 ### REST API Call Pattern
@@ -541,6 +576,7 @@ When `JIRA_MODE = "REST"`, all Jira operations follow this pattern:
    > Generated: [current timestamp]
    > Mode: Fallback (Atlassian MCP unavailable)
    > Issue Type: [Bug/Task]
+   > Priority: [selectedPriority from Phase 5 step 7, or "Medium" if step 7 was skipped in OFFLINE mode]
 
    ---
 
@@ -559,8 +595,11 @@ When `JIRA_MODE = "REST"`, all Jira operations follow this pattern:
    1. Copy the Summary and Description above
    2. Create a new issue in your Jira project
    3. Set the issue type to: [Bug/Task]
-   4. Add the labels listed above
-   5. Review and adjust as needed
+   4. Set priority to: [selectedPriority]
+   5. Assign to yourself or a teammate (was skipped in offline mode)
+   6. Add the labels listed above
+   7. **Attach the source debug report file**: [absolute path to source/debug/report.md]
+   8. Review and adjust as needed
    ```
 
 4. **Notify user**
@@ -596,14 +635,16 @@ When `JIRA_MODE = "REST"`, all Jira operations follow this pattern:
 
 3. **Write issue payload**
 
-   Write to `.claude/tmp/jira-payload.json`:
+   Write to `.claude/tmp/jira-payload.json`. Include `priority` and `assignee_account_id` from Phase 5 step 7 (omit `assignee_account_id` if user chose "Leave unassigned"):
    ```json
    {
      "project_key": "[projectKey]",
      "issue_type": "[validated issue type from step 2]",
      "summary": "[extracted from jira-writer output]",
      "description": "[extracted from jira-writer output]",
-     "labels": ["[sanitized labels from Phase 5]"]
+     "labels": ["[sanitized labels from Phase 5]"],
+     "priority": "[selectedPriority from Phase 5 step 7]",
+     "assignee_account_id": "[selectedAssigneeAccountId from Phase 5 step 7, or omit key if null]"
    }
    ```
 
@@ -627,9 +668,18 @@ When `JIRA_MODE = "REST"`, all Jira operations follow this pattern:
      - Save draft to `.claude/reports/jira-drafts/draft-{timestamp}.md`
      - Display: "REST API failed. Draft saved to: [path]"
 
-5. **Store Jira link in source report** — same frontmatter logic as MCP path, but use `{baseUrl}/browse/{key}` for `jira_url`
+5. **Attach source debug report to the new issue** (REST mode only)
 
-6. **Clean up** — delete `.claude/tmp/jira-payload.json`
+   The source debugging report (path determined in Phase 2) is attached as a markdown file so the full original artifact lives on the ticket alongside the formatted summary.
+
+   Bash: `python3 {SCRIPT_PATH} --action attach-file --config .claude/jira-rest-config.json --issue-key {key} --file-path {abs/path/to/source/debug/report.md}`
+
+   - If **exit 0**: Append to the success display: `Attachment: {filename} ({size} bytes)`.
+   - If **exit != 0**: Non-fatal. Display: `Note: failed to attach source report to {key} — you can attach it manually in Jira. (error: [error message])`. Do NOT abort.
+
+6. **Store Jira link in source report** — same frontmatter logic as MCP path, but use `{baseUrl}/browse/{key}` for `jira_url`
+
+7. **Clean up** — delete `.claude/tmp/jira-payload.json`
 
 #### If UPDATE_MODE = false and JIRA_MODE = "MCP" (Create New Issue)
 
@@ -659,9 +709,13 @@ When `JIRA_MODE = "REST"`, all Jira operations follow this pattern:
    summary: [extracted from jira-writer output]
    description: [extracted from jira-writer output - preserve markdown formatting]
    additional_fields: {
-     labels: [sanitized labels array]
+     labels: [sanitized labels array],
+     priority: { name: "[selectedPriority from Phase 5 step 7]" },
+     assignee: { accountId: "[selectedAssigneeAccountId from Phase 5 step 7]" }  // omit assignee key entirely if user chose "Leave unassigned"
    }
    ```
+
+   **Note**: file attachment is not supported by the Atlassian MCP tools today — in MCP mode the source debug report is NOT attached. The full report content is already embedded in the description via jira-writer.
 
 3. **Handle success**
 

--- a/agent-team-creator/scripts/jira_client.py
+++ b/agent-team-creator/scripts/jira_client.py
@@ -313,7 +313,16 @@ def action_get_issue_types(config, args):
 
 
 def action_create_issue(config, args):
-    """Create a new Jira issue."""
+    """Create a new Jira issue.
+
+    Required payload fields: project_key, issue_type, summary.
+    Optional payload fields:
+      - description (markdown, converted to wiki markup)
+      - labels (list of strings)
+      - priority (string name, e.g. "High", "Medium", "P1")
+      - assignee_account_id (Atlassian accountId — get yours via get-current-user)
+      - parent_key (issue key, e.g. "GCI-40"; pair with issue_type="Subtask")
+    """
     payload = read_payload(args.payload_file)
 
     for field in ("project_key", "issue_type", "summary"):
@@ -323,20 +332,23 @@ def action_create_issue(config, args):
     description = payload.get("description", "")
     wiki_description = markdown_to_wiki(description)
 
-    body = {
-        "fields": {
-            "project": {"key": payload["project_key"]},
-            "issuetype": {"name": payload["issue_type"]},
-            "summary": payload["summary"][:255],
-            "description": wiki_description,
-        }
+    fields = {
+        "project": {"key": payload["project_key"]},
+        "issuetype": {"name": payload["issue_type"]},
+        "summary": payload["summary"][:255],
+        "description": wiki_description,
     }
 
-    labels = payload.get("labels", [])
-    if labels:
-        body["fields"]["labels"] = labels
+    if payload.get("labels"):
+        fields["labels"] = payload["labels"]
+    if payload.get("priority"):
+        fields["priority"] = {"name": payload["priority"]}
+    if payload.get("assignee_account_id"):
+        fields["assignee"] = {"accountId": payload["assignee_account_id"]}
+    if payload.get("parent_key"):
+        fields["parent"] = {"key": payload["parent_key"]}
 
-    data = make_request(config, "POST", "/rest/api/2/issue", body)
+    data = make_request(config, "POST", "/rest/api/2/issue", {"fields": fields})
     issue_key = data.get("key", "")
     return {
         "ok": True,
@@ -390,6 +402,134 @@ def action_add_comment(config, args):
     return {"ok": True, "commentId": data.get("id", "")}
 
 
+def action_update_issue(config, args):
+    """Patch fields on an existing Jira issue.
+
+    Payload fields (any subset, all optional):
+      - summary           (string)
+      - description       (markdown, converted to wiki markup)
+      - labels            (list of strings — REPLACES existing labels)
+      - priority          (string name)
+      - assignee_account_id (Atlassian accountId, or null to unassign)
+      - fields            (dict of raw Jira field overrides — escape hatch)
+    """
+    if not args.issue_key:
+        error_exit("--issue-key required for update-issue", 2)
+    payload = read_payload(args.payload_file)
+
+    fields = {}
+    if "summary" in payload:
+        fields["summary"] = payload["summary"][:255]
+    if "description" in payload:
+        fields["description"] = markdown_to_wiki(payload["description"])
+    if "labels" in payload:
+        fields["labels"] = payload["labels"]
+    if "priority" in payload:
+        fields["priority"] = {"name": payload["priority"]}
+    if "assignee_account_id" in payload:
+        fields["assignee"] = (
+            None if payload["assignee_account_id"] is None
+            else {"accountId": payload["assignee_account_id"]}
+        )
+    if "fields" in payload:  # raw escape hatch
+        fields.update(payload["fields"])
+
+    if not fields:
+        error_exit("update-issue payload must set at least one field", 2)
+
+    make_request(config, "PUT", f"/rest/api/2/issue/{args.issue_key}", {"fields": fields})
+    return {
+        "ok": True,
+        "key": args.issue_key,
+        "url": f"{config['baseUrl']}/browse/{args.issue_key}",
+        "updated": list(fields.keys()),
+    }
+
+
+def action_attach_file(config, args):
+    """Upload a file as an attachment to a Jira issue.
+
+    Requires --issue-key and --file-path. Multipart upload to
+    /rest/api/2/issue/{key}/attachments. Sets X-Atlassian-Token: no-check
+    as required by Atlassian for attachment endpoints.
+    """
+    if not args.issue_key:
+        error_exit("--issue-key required for attach-file", 2)
+    if not args.file_path:
+        error_exit("--file-path required for attach-file", 2)
+    if not os.path.isfile(args.file_path):
+        error_exit(f"File not found: {args.file_path}", 2)
+
+    filename = os.path.basename(args.file_path)
+    with open(args.file_path, "rb") as f:
+        file_bytes = f.read()
+
+    boundary = "----JiraClientBoundary7349"
+    body = (
+        f"--{boundary}\r\n"
+        f'Content-Disposition: form-data; name="file"; filename="{filename}"\r\n'
+        f"Content-Type: application/octet-stream\r\n\r\n"
+    ).encode() + file_bytes + f"\r\n--{boundary}--\r\n".encode()
+
+    url = f"{config['baseUrl']}/rest/api/2/issue/{args.issue_key}/attachments"
+    credentials = f"{config['email']}:{config['apiToken']}"
+    auth_header = base64.b64encode(credentials.encode()).decode()
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Authorization": f"Basic {auth_header}",
+            "Accept": "application/json",
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+            "X-Atlassian-Token": "no-check",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        handle_http_error(e)
+    except urllib.error.URLError as e:
+        error_exit(f"Cannot reach {config['baseUrl']}: {e.reason}", 3)
+
+    if not isinstance(data, list) or not data:
+        error_exit("Unexpected attachment response (expected non-empty list)", 4)
+    att = data[0]
+    return {
+        "ok": True,
+        "key": args.issue_key,
+        "attachmentId": att.get("id", ""),
+        "filename": att.get("filename", filename),
+        "size": att.get("size", len(file_bytes)),
+    }
+
+
+def action_delete_issue(config, args):
+    """Delete a Jira issue. Cascades to subtasks by default.
+
+    Use --no-cascade to refuse deletion if subtasks exist.
+    """
+    if not args.issue_key:
+        error_exit("--issue-key required for delete-issue", 2)
+    cascade = "false" if args.no_cascade else "true"
+    make_request(
+        config, "DELETE",
+        f"/rest/api/2/issue/{args.issue_key}?deleteSubtasks={cascade}",
+    )
+    return {"ok": True, "key": args.issue_key, "deleted": True, "cascade": cascade == "true"}
+
+
+def action_get_current_user(config, _args):
+    """Return the current user's identity, including accountId.
+
+    Same endpoint as verify-auth but a clearer name for the common
+    use case of "give me my accountId so I can self-assign".
+    """
+    return action_verify_auth(config, _args)
+
+
 # --- Utilities ---
 
 def read_payload(path):
@@ -428,8 +568,12 @@ ACTIONS = {
     "search-issues": action_search_issues,
     "get-issue-types": action_get_issue_types,
     "create-issue": action_create_issue,
+    "update-issue": action_update_issue,
+    "delete-issue": action_delete_issue,
+    "attach-file": action_attach_file,
     "get-issue": action_get_issue,
     "add-comment": action_add_comment,
+    "get-current-user": action_get_current_user,  # clearer-named alias for verify-auth
     "get-accessible-resources": action_verify_auth,  # alias — same endpoint
 }
 
@@ -442,6 +586,9 @@ def main():
     parser.add_argument("--project", help="Jira project key")
     parser.add_argument("--query", help="Search query string")
     parser.add_argument("--payload-file", dest="payload_file", help="Path to JSON payload file")
+    parser.add_argument("--file-path", dest="file_path", help="Path to local file (for attach-file)")
+    parser.add_argument("--no-cascade", dest="no_cascade", action="store_true",
+                        help="For delete-issue: refuse to delete if subtasks exist")
     args = parser.parse_args()
 
     config = read_config(args.config)

--- a/agent-team-creator/scripts/jira_client.py
+++ b/agent-team-creator/scripts/jira_client.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Jira REST API v2 client for Claude Code plugin fallback.
+"""Jira REST API client for Claude Code plugin fallback.
 
 Zero external dependencies — uses only Python 3 stdlib.
 Credentials read from config file (never CLI args).
@@ -40,25 +40,27 @@ def read_config(path):
 
 # --- HTTP ---
 
-def make_request(config, method, path, body=None, timeout=15):
-    """Execute an authenticated HTTP request to Jira REST API v2.
-
-    Returns parsed JSON response.
-    Raises urllib.error.HTTPError or urllib.error.URLError on failure.
-    """
+def _build_authed_request(config, method, path, body):
+    """Build an authenticated urllib.Request (no I/O)."""
     url = f"{config['baseUrl']}{path}"
     credentials = f"{config['email']}:{config['apiToken']}"
     auth_header = base64.b64encode(credentials.encode()).decode()
-
     headers = {
         "Authorization": f"Basic {auth_header}",
         "Content-Type": "application/json",
         "Accept": "application/json",
     }
-
     data = json.dumps(body).encode() if body else None
-    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    return urllib.request.Request(url, data=data, headers=headers, method=method)
 
+
+def make_request(config, method, path, body=None, timeout=15):
+    """Execute an authenticated HTTP request to Jira REST API.
+
+    Returns parsed JSON response.
+    Calls error_exit() on HTTP errors (auth, network, server, jira-api).
+    """
+    req = _build_authed_request(config, method, path, body)
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             if resp.status == 204:
@@ -70,6 +72,22 @@ def make_request(config, method, path, body=None, timeout=15):
         if "timed out" in str(e.reason):
             error_exit("Request timed out", 3)
         error_exit(f"Cannot reach {config['baseUrl']}: {e.reason}", 3)
+
+
+def try_request(config, method, path, body=None, timeout=10):
+    """Non-fatal variant of make_request: returns None on any failure.
+
+    Use for optional/secondary calls where the action should still succeed
+    if this call fails (e.g., approximate-count for duplicate detection).
+    """
+    req = _build_authed_request(config, method, path, body)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            if resp.status == 204:
+                return {}
+            return json.loads(resp.read().decode())
+    except Exception:
+        return None
 
 
 def make_request_with_retry(config, method, path, body=None, retries=1):
@@ -238,14 +256,27 @@ def action_get_projects(config, args):
 
 
 def action_search_issues(config, args):
-    """Search issues via JQL."""
+    """Search issues via JQL using /rest/api/3/search/jql.
+
+    Atlassian removed /rest/api/2/search and /rest/api/3/search (HTTP 410)
+    in favor of a token-paginated endpoint that no longer returns `total`.
+    To preserve duplicate-detection UX ("Found ~47 similar issues"), we
+    fetch an approximate count from /rest/api/3/search/approximate-count
+    in a separate non-fatal call. Failures there degrade to the page size.
+
+    See: https://developer.atlassian.com/changelog/#CHANGE-2046
+    """
     payload = read_payload(args.payload_file)
+    jql = payload.get("jql", "")
     body = {
-        "jql": payload.get("jql", ""),
+        "jql": jql,
         "maxResults": payload.get("maxResults", 5),
         "fields": payload.get("fields", ["summary", "status", "created", "key"]),
     }
-    data = make_request(config, "POST", "/rest/api/2/search", body)
+    if payload.get("nextPageToken"):
+        body["nextPageToken"] = payload["nextPageToken"]
+
+    data = make_request(config, "POST", "/rest/api/3/search/jql", body)
     issues = []
     for issue in data.get("issues", []):
         fields = issue.get("fields", {})
@@ -256,7 +287,16 @@ def action_search_issues(config, args):
             "status": status.get("name", "") if isinstance(status, dict) else str(status),
             "created": fields.get("created", ""),
         })
-    return {"ok": True, "issues": issues, "total": data.get("total", 0)}
+
+    count_data = try_request(
+        config, "POST", "/rest/api/3/search/approximate-count", {"jql": jql}
+    )
+    total = count_data.get("count", len(issues)) if count_data else len(issues)
+
+    result = {"ok": True, "issues": issues, "total": total}
+    if data.get("nextPageToken"):
+        result["nextPageToken"] = data["nextPageToken"]
+    return result
 
 
 def action_get_issue_types(config, args):
@@ -395,7 +435,7 @@ ACTIONS = {
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Jira REST API v2 client")
+    parser = argparse.ArgumentParser(description="Jira REST API client")
     parser.add_argument("--action", required=True, choices=ACTIONS.keys())
     parser.add_argument("--config", required=True, help="Path to credential config JSON")
     parser.add_argument("--issue-key", dest="issue_key", help="Jira issue key (e.g., PROJ-123)")

--- a/agent-team-creator/skills/jira-rest-api/SKILL.md
+++ b/agent-team-creator/skills/jira-rest-api/SKILL.md
@@ -4,7 +4,7 @@ description: Knowledge for invoking the Jira REST API via jira_client.py.
   Used by commands (generate-jira-task, update-generated-report) as a fallback
   when the Atlassian MCP plugin is unavailable. Contains credential configuration,
   script invocation syntax, action reference, error handling, and security guidance.
-version: 1.1.0
+version: 1.2.0
 ---
 
 # Jira REST API Client
@@ -46,7 +46,9 @@ python3 {SCRIPT_PATH} \
   [--issue-key PROJ-123] \
   [--project PROJ] \
   [--query "search term"] \
-  [--payload-file .claude/tmp/jira-payload.json]
+  [--payload-file .claude/tmp/jira-payload.json] \
+  [--file-path /abs/path/to/file] \
+  [--no-cascade]
 ```
 
 Credentials are ALWAYS read from the config file. Never pass tokens as CLI arguments.
@@ -55,14 +57,18 @@ Credentials are ALWAYS read from the config file. Never pass tokens as CLI argum
 
 | Action | Required Flags | Optional Flags | Returns |
 |--------|---------------|----------------|---------|
-| `verify-auth` | `--config` | — | `{ok, email, displayName}` |
+| `verify-auth` | `--config` | — | `{ok, email, displayName, accountId}` |
+| `get-current-user` | `--config` | — | `{ok, email, displayName, accountId}` (clearer-named alias for `verify-auth`) |
 | `get-projects` | `--config` | `--query` | `{ok, projects: [{key,name,id}]}` |
 | `search-issues` | `--config --payload-file` | — | `{ok, issues: [{key,summary,status,created}], total, nextPageToken?}` |
-| `get-issue-types` | `--config --project` | — | `{ok, issueTypes: [{name,id}]}` |
+| `get-issue-types` | `--config --project` | — | `{ok, issueTypes: [{name,id,subtask}]}` |
 | `create-issue` | `--config --payload-file` | — | `{ok, key, url}` |
+| `update-issue` | `--config --issue-key --payload-file` | — | `{ok, key, url, updated: [field-names]}` |
+| `delete-issue` | `--config --issue-key` | `--no-cascade` | `{ok, key, deleted, cascade}` |
+| `attach-file` | `--config --issue-key --file-path` | — | `{ok, key, attachmentId, filename, size}` |
 | `get-issue` | `--config --issue-key` | — | `{ok, key, summary, description, status, comments}` |
 | `add-comment` | `--config --issue-key --payload-file` | — | `{ok, commentId}` |
-| `get-accessible-resources` | `--config` | — | `{ok, baseUrl}` (alias for verify-auth) |
+| `get-accessible-resources` | `--config` | — | `{ok, baseUrl}` (alias for `verify-auth`) |
 
 ### Notes on `search-issues`
 
@@ -74,6 +80,77 @@ Credentials are ALWAYS read from the config file. Never pass tokens as CLI argum
   `maxResults`, the response includes `nextPageToken`; pass it back in the next
   payload's `nextPageToken` field to fetch the next page. There is no `startAt`.
 - Default `maxResults` is `5`; payload may override (Jira caps at 100).
+
+### Payload pattern: `create-issue`
+
+```json
+{
+  "project_key": "GCI",
+  "issue_type": "Task",
+  "summary": "Short title",
+  "description": "Markdown body. Converted to wiki markup automatically.",
+  "labels": ["claude-code", "automation"],
+  "priority": "Medium",
+  "assignee_account_id": "712020:abc-...",
+  "parent_key": "GCI-40"
+}
+```
+
+- `project_key`, `issue_type`, `summary` are required; everything else is optional.
+- `priority` accepts the **name** as it appears in Jira (e.g. `Highest`, `High`, `Medium`,
+  `Low`, `Lowest`, or custom names like `P0`–`P3` if defined).
+- `assignee_account_id` must be an Atlassian accountId (get yours via `get-current-user`).
+- `parent_key` makes the new issue a child. Pair with `issue_type: "Subtask"` when the
+  project's subtask type is named `Subtask` (call `get-issue-types --project KEY` to
+  confirm the exact name).
+
+### Payload pattern: `update-issue`
+
+```json
+{
+  "summary": "New title (optional)",
+  "description": "New markdown body (optional)",
+  "labels": ["replaces", "existing", "labels"],
+  "priority": "Low",
+  "assignee_account_id": "712020:abc-...",
+  "fields": { "duedate": "2026-12-31" }
+}
+```
+
+- All top-level keys are optional but at least one must be set.
+- `labels` **replaces** the existing label list (Jira's PUT semantics).
+- Set `assignee_account_id` to `null` to unassign.
+- `fields` is a raw escape hatch: any key/value here is merged into the Jira `fields`
+  object verbatim. Use for fields the script doesn't model (e.g., `duedate`, `customfield_10001`).
+
+### Invocation pattern: `attach-file`
+
+```bash
+python3 {SCRIPT_PATH} \
+  --action attach-file \
+  --config .claude/jira-rest-config.json \
+  --issue-key GCI-40 \
+  --file-path /abs/path/to/report.md
+```
+
+- No payload file. The file is uploaded as `multipart/form-data`.
+- Endpoint sends header `X-Atlassian-Token: no-check` (required by Atlassian for attachments).
+- Markdown attachments display inline in the Jira UI; logs/screenshots/PDFs are linked.
+- Multiple files require multiple invocations.
+
+### Invocation pattern: `delete-issue`
+
+```bash
+python3 {SCRIPT_PATH} \
+  --action delete-issue \
+  --config .claude/jira-rest-config.json \
+  --issue-key GCI-40 \
+  [--no-cascade]
+```
+
+- Default cascades subtask deletion (`?deleteSubtasks=true`).
+- `--no-cascade` makes Jira refuse to delete an issue that has subtasks.
+- This is irreversible — commands should confirm with the user first.
 
 ## Exit Codes
 

--- a/agent-team-creator/skills/jira-rest-api/SKILL.md
+++ b/agent-team-creator/skills/jira-rest-api/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: Jira REST API
-description: Knowledge for invoking the Jira REST API v2 via jira_client.py.
+description: Knowledge for invoking the Jira REST API via jira_client.py.
   Used by commands (generate-jira-task, update-generated-report) as a fallback
   when the Atlassian MCP plugin is unavailable. Contains credential configuration,
   script invocation syntax, action reference, error handling, and security guidance.
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Jira REST API Client
 
 This skill documents the REST API fallback tier for the Jira integration. When the
 Atlassian MCP plugin is unavailable, commands use the `jira_client.py` script to
-interact with Jira directly via REST API v2.
+interact with Jira directly via REST API v2 — except for issue search, which uses
+the v3 `/search/jql` endpoint after Atlassian removed the v2/v3 `/search` routes
+(HTTP 410, see [CHANGE-2046](https://developer.atlassian.com/changelog/#CHANGE-2046)).
 
 ## Architecture
 
@@ -55,12 +57,23 @@ Credentials are ALWAYS read from the config file. Never pass tokens as CLI argum
 |--------|---------------|----------------|---------|
 | `verify-auth` | `--config` | — | `{ok, email, displayName}` |
 | `get-projects` | `--config` | `--query` | `{ok, projects: [{key,name,id}]}` |
-| `search-issues` | `--config --payload-file` | — | `{ok, issues: [{key,summary,status}], total}` |
+| `search-issues` | `--config --payload-file` | — | `{ok, issues: [{key,summary,status,created}], total, nextPageToken?}` |
 | `get-issue-types` | `--config --project` | — | `{ok, issueTypes: [{name,id}]}` |
 | `create-issue` | `--config --payload-file` | — | `{ok, key, url}` |
 | `get-issue` | `--config --issue-key` | — | `{ok, key, summary, description, status, comments}` |
 | `add-comment` | `--config --issue-key --payload-file` | — | `{ok, commentId}` |
 | `get-accessible-resources` | `--config` | — | `{ok, baseUrl}` (alias for verify-auth) |
+
+### Notes on `search-issues`
+
+- Endpoint: `POST /rest/api/3/search/jql` (the v2/v3 `/search` routes were removed by Atlassian).
+- `total` is an **approximate** count fetched from `/rest/api/3/search/approximate-count`
+  in a separate non-fatal call. If that secondary call fails, `total` falls back to
+  `len(issues)` so the search still returns useful data.
+- Pagination is **token-based**, not offset-based. When more results exist beyond
+  `maxResults`, the response includes `nextPageToken`; pass it back in the next
+  payload's `nextPageToken` field to fetch the next page. There is no `startAt`.
+- Default `maxResults` is `5`; payload may override (Jira caps at 100).
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary

Closes the script's coverage gap surfaced by the v1.1.2 capability test report. Adds 4 new actions (`update-issue`, `attach-file`, `delete-issue`, `get-current-user`), extends `create-issue` payload with `priority` / `assignee_account_id` / `parent_key`, and wires `/generate-jira-task` to use them (priority + assignee prompts in Phase 5; source debug report attached automatically in REST mode).

**Stacked on PR #14** — branched from `release/v1.1.2-jira-search-fix` so this includes the v1.1.2 search fix. Should merge **after** PR #14 (or be rebased onto main once #14 is in).

Version bump: `1.1.2 → 1.2.0` (minor — additive, no breaking changes).

## What changed

| File | What |
|------|------|
| `agent-team-creator/scripts/jira_client.py` | +4 actions, extended `create-issue` payload, new CLI flags `--file-path` and `--no-cascade`. Refactor: `create-issue` body assembles `fields` dict incrementally to accommodate optional fields. |
| `agent-team-creator/skills/jira-rest-api/SKILL.md` | Action reference table updated with 5 new entries; added payload patterns for `create-issue` (extended), `update-issue`, `attach-file`, `delete-issue`. Skill version `1.1.0 → 1.2.0`. |
| `agent-team-creator/commands/generate-jira-task.md` | Phase 5 step 7 (new): auto-derive priority + resolve current user + prompt user. Phase 6 REST: payload includes priority/assignee, new step 5 attaches source report. Phase 6 MCP: `additional_fields` includes priority/assignee. Phase 6 OFFLINE: draft includes priority + attach instruction. |
| `CHANGELOG.md` | New `[1.2.0] - 2026-05-08` entry under Added/Changed/Internal. |
| `agent-team-creator/.claude-plugin/plugin.json` | Version `1.1.2 → 1.2.0`. |
| `.claude-plugin/marketplace.json` | Version `1.1.2 → 1.2.0`. |

## Test plan

End-to-end verified against `amrize-industrial.atlassian.net` (project `GCI`) — all new actions exercised through the **SCRIPT** (not direct API):

- [x] `get-current-user` returned my accountId
- [x] `create-issue` with `priority` + `assignee_account_id` + `labels` in one call → `GCI-42`
- [x] `update-issue` patched 4 fields (`summary`, `labels`, `priority`, `assignee`)
- [x] `attach-file` uploaded markdown (156 bytes) → `attachmentId: 20774`
- [x] `create-issue` with `parent_key` created subtask → `GCI-43`
- [x] `delete-issue` (cascade) removed `GCI-42` + `GCI-43` in one call
- [x] Post-test `get-issue` on both keys returned 404 — clean cleanup confirmed
- [ ] Reviewer to spot-check command flow before merge

## Post-merge steps

After this and PR #14 both merge, tag the merged main commit:

```bash
git checkout main && git pull
git tag -a v1.2.0 -m "Release v1.2.0"
git push origin v1.2.0
```

Then announce v1.2.0 release (separate task — not part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)